### PR TITLE
Update highlights.scm to highlight kv pairs and due dates

### DIFF
--- a/languages/todo.txt/highlights.scm
+++ b/languages/todo.txt/highlights.scm
@@ -1,7 +1,6 @@
 (done_task) @comment
 (task (priority) @keyword)
 (task (date) @comment)
-(task (kv) @comment)
 (task (project) @string)
 (task (context) @type)
 ((kv) @boolean

--- a/languages/todo.txt/highlights.scm
+++ b/languages/todo.txt/highlights.scm
@@ -4,3 +4,7 @@
 (task (kv) @comment)
 (task (project) @string)
 (task (context) @type)
+((kv) @boolean
+ (#match? @boolean "^due:"))
+((kv) @string.other.metadata
+ (#not-match? @string.other.metadata "^due:"))


### PR DESCRIPTION
Include a match for kv string starting with `due:` and highlight them as `string.other.metadata` capture groups while any other kv string is highlighted with the `boolean` capture group.